### PR TITLE
ログアウト登録画面の作成

### DIFF
--- a/app/assets/stylesheets/_credit.scss
+++ b/app/assets/stylesheets/_credit.scss
@@ -30,7 +30,7 @@
 }
 
 .cp-chapter{
-  margin-left: 166px;
+  margin-left: -204px;
   font-weight: bold;
 }
 

--- a/app/assets/stylesheets/_logout.scss
+++ b/app/assets/stylesheets/_logout.scss
@@ -1,0 +1,34 @@
+.l-p{
+  margin: auto;
+}
+
+.l-page {
+  display: flex;
+  margin-left: 205px;
+  padding-top: 40px;
+}
+
+.lp{
+  width: 700px;
+  height: 568px;
+  margin-left: 40px;
+}
+
+.lp-info{
+  background-color: #ffffff;
+  padding: 64px;
+}
+
+.lp-info-lo{
+  width: 320px;
+  background: #ea352d;
+  margin: auto;
+  height: 45px;
+  font-size: 14px;
+  line-height: 45px;
+  text-align:center;
+}
+
+.lp-info-lot{
+  color: #ffffff;
+}

--- a/app/assets/stylesheets/_side_bar.scss
+++ b/app/assets/stylesheets/_side_bar.scss
@@ -13,11 +13,12 @@ a {
 .mypage-nav-list-item {
   display: block;
   min-height: 14px;
-  padding: 16px;
+  padding: 16px 0 16px 20px;
   background: #fff;
   font-size: 14px;
   color: #333;
   margin-top: 1px;
+  text-align: left;
 }
 .mypage-nav-list-item-myp{
   display: block;
@@ -29,8 +30,9 @@ a {
   font-weight: bold;
 }
 .mypage-nav-head{
-  margin: 40px 0 0 0;
+  margin: 40px 0 2px 0;
   font-size: 16px;
   font-weight: bold;
   height: 24px;
+  text-align: left;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @import "./details";
 @import "./footer";
 @import "./header";
+@import "./logout";
 @import "./mypage";
 @import "./products";
 @import "./profile";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  
+  protect_from_forgery with: :exception
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,4 +9,7 @@ class UsersController < ApplicationController
   def credit
   end
 
+  def logout
+  end
+
 end

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,0 +1,13 @@
+= render "products/header"
+
+.l-p
+  .l-page
+    .side_bar
+      = render "products/side_bar"
+
+    .lp      
+      .lp-info
+        .lp-info-lo
+          = link_to "ログアウト", "#", class: "lp-info-lot"
+
+= render "products/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       get 'mypage'
       get 'profile'
       get 'credit'
+      get 'logout'
     end
   end
   resources :details


### PR DESCRIPTION
# What
メルカリアプリ ログアウト登録画面のコーディング

# Why
メルカリのログアウト登録画面を作成し、それに付随する機能を
実装していくため

https://i.gyazo.com/15cd7cf2989116238de6742d4776b083.png

画面は、「http://localhost:3000/users/:id/logout#」　です。