### PR TITLE
パンくずリスト作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,5 @@ gem 'carrierwave'
 gem 'fog-aws'
 
 gem 'devise'
+
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -302,6 +304,7 @@ DEPENDENCIES
   devise
   erb2haml
   fog-aws
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 @import "./base/base";
 @import "./base/registration-base";
 @import "./base/single-base";
+@import "./base/breadcrumbs";
 
 @import "./user";
 @import "./credit";

--- a/app/assets/stylesheets/base/_breadcrumbs.scss
+++ b/app/assets/stylesheets/base/_breadcrumbs.scss
@@ -1,0 +1,4 @@
+.breadcrumb{
+  text-align: left;
+  margin-left: 130px;
+}

--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -37,3 +37,5 @@
       = link_to image_tag("person.png",height:"38px", width:"38px"),"/users/:id/mypage"
       マイページ
 
+  
+

--- a/app/views/shared/_breadcrumb.html.haml
+++ b/app/views/shared/_breadcrumb.html.haml
@@ -1,0 +1,2 @@
+.breadcrumb
+  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/users/mypage.html.haml
+++ b/app/views/users/mypage.html.haml
@@ -1,4 +1,7 @@
 = render "products/header"
+- breadcrumb :mypage
+= render "shared/breadcrumb"
+
 
 .m-p
   .m-page

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -1,4 +1,6 @@
 = render "products/header"
+- breadcrumb :profile
+= render "shared/breadcrumb"
 
 .p-p
   .p-page

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,40 @@
+
+# ルート
+crumb :root do
+  link "トップページ", root_path
+end
+
+# マイページ
+crumb :mypage do
+  link "マイページ", mypage_user_path(:id)
+end
+
+crumb :profile do
+  link "プロフィール", profile_user_path(:id)
+  parent :mypage
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
＃What
パンくずリストを作成する

＃why
ユーザーが今WEBサイト内のどの位置にいるのかを視覚的に分かりやすくするため、上位の階層となるWEBページを階層順にリストアップしてリンクを設置したリストのことです

<img width="1410" alt="ba1741163a2798b3b7d456a656586572" src="https://user-images.githubusercontent.com/57896328/71797185-4f2d1580-3090-11ea-946e-fa509b520dec.png">
